### PR TITLE
Embed review progress in file names and reduce font sizes

### DIFF
--- a/packages/app/src/ui/tailwind.config.js
+++ b/packages/app/src/ui/tailwind.config.js
@@ -10,7 +10,21 @@ export default {
         'diff-add': '#22c55e',
         'diff-delete': '#ef4444',
         'diff-context': '#64748b',
-      }
+      },
+      fontSize: {
+        '2xs': ['10px', '14px'],
+        '3xs': ['9px', '12px'],
+        '4xs': ['8px', '11px'],
+        '5xs': ['7px', '10px'],
+      },
+      spacing: {
+        '0.25': '1px',
+        '0.75': '3px',
+      },
+      lineHeight: {
+        'extra-tight': '1.1',
+        'super-tight': '1.0',
+      },
     },
   },
   plugins: [],

--- a/packages/frontend/src/components/DiffViewer.tsx
+++ b/packages/frontend/src/components/DiffViewer.tsx
@@ -52,14 +52,14 @@ function DiffLineComponent({ line, hunkId, notes, onAddNote }: DiffLineProps) {
       <div className="flex">
         {/* Old line (left side) */}
         <div className={`flex-1 ${line.type === 'delete' ? getLineClass() : darkMode ? 'bg-gray-900' : 'bg-gray-50'} border-r ${darkMode ? 'border-gray-700' : 'border-gray-300'}`}>
-          <div className="flex group hover:bg-gray-750">
-            <div className={`flex-none w-12 px-2 py-1 text-xs ${darkMode ? 'text-gray-500' : 'text-gray-600'} text-right`}>
+          <div className={`flex group ${darkMode ? 'hover:bg-gray-750' : 'hover:bg-blue-50'}`}>
+            <div className={`flex-none w-6 px-1 py-0.25 text-3xs ${darkMode ? 'text-gray-500' : 'text-gray-600'} text-right`}>
               {line.type !== 'add' ? (line.oldLineNumber || '') : ''}
             </div>
-            <div className={`flex-none w-6 px-1 py-1 text-xs text-center font-mono ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+            <div className={`flex-none w-4 px-0.5 py-0.25 text-3xs text-center font-mono ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}>
               {line.type === 'delete' ? '-' : ' '}
             </div>
-            <div className={`flex-1 px-2 py-1 font-mono text-sm ${darkMode ? 'text-white' : 'text-gray-900'} whitespace-pre-wrap break-all overflow-hidden`}>
+            <div className={`flex-1 px-1 py-0.25 font-mono text-2xs leading-extra-tight ${darkMode ? 'text-white' : 'text-gray-900'} whitespace-pre-wrap break-all overflow-hidden`}>
               {line.type !== 'add' ? line.content : ''}
             </div>
           </div>
@@ -67,23 +67,23 @@ function DiffLineComponent({ line, hunkId, notes, onAddNote }: DiffLineProps) {
         
         {/* New line (right side) */}
         <div className={`flex-1 ${line.type === 'add' ? getLineClass() : darkMode ? 'bg-gray-900' : 'bg-gray-50'}`}>
-          <div className="flex group hover:bg-gray-750">
-            <div className={`flex-none w-12 px-2 py-1 text-xs ${darkMode ? 'text-gray-500' : 'text-gray-600'} text-right`}>
+          <div className={`flex group ${darkMode ? 'hover:bg-gray-750' : 'hover:bg-blue-50'}`}>
+            <div className={`flex-none w-6 px-1 py-0.25 text-3xs ${darkMode ? 'text-gray-500' : 'text-gray-600'} text-right`}>
               {line.type !== 'delete' ? (line.newLineNumber || '') : ''}
             </div>
-            <div className={`flex-none w-6 px-1 py-1 text-xs text-center font-mono ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+            <div className={`flex-none w-4 px-0.5 py-0.25 text-3xs text-center font-mono ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}>
               {line.type === 'add' ? '+' : ' '}
             </div>
-            <div className={`flex-1 px-2 py-1 font-mono text-sm ${darkMode ? 'text-white' : 'text-gray-900'} whitespace-pre-wrap break-all overflow-hidden`}>
+            <div className={`flex-1 px-1 py-0.25 font-mono text-2xs leading-extra-tight ${darkMode ? 'text-white' : 'text-gray-900'} whitespace-pre-wrap break-all overflow-hidden`}>
               {line.type !== 'delete' ? line.content : ''}
             </div>
-            <div className="flex-none opacity-0 group-hover:opacity-100 px-2 py-1">
+            <div className="flex-none opacity-0 group-hover:opacity-100 px-1 py-0.25">
               <button
                 onClick={() => onAddNote(hunkId, line.newLineNumber || line.oldLineNumber)}
                 className={`${darkMode ? 'text-gray-400 hover:text-blue-400' : 'text-gray-500 hover:text-blue-600'} transition-colors`}
                 title={`Add note to line ${line.newLineNumber || line.oldLineNumber}`}
               >
-                <MessageSquare className="w-4 h-4" />
+                <MessageSquare className="w-3 h-3" />
               </button>
             </div>
           </div>
@@ -96,26 +96,26 @@ function DiffLineComponent({ line, hunkId, notes, onAddNote }: DiffLineProps) {
   return (
     <div>
       {/* コード行 */}
-      <div className={`flex group ${darkMode ? 'hover:bg-gray-750' : 'hover:bg-gray-100'} ${getLineClass()} border-l-2`}>
-        <div className={`flex-none w-12 px-2 py-1 text-xs ${darkMode ? 'text-gray-500' : 'text-gray-600'} text-right`}>
+      <div className={`flex group ${darkMode ? 'hover:bg-gray-750' : 'hover:bg-blue-50'} ${getLineClass()} border-l-2`}>
+        <div className={`flex-none w-6 px-1 py-0.25 text-3xs ${darkMode ? 'text-gray-500' : 'text-gray-600'} text-right`}>
           {line.oldLineNumber || ''}
         </div>
-        <div className={`flex-none w-12 px-2 py-1 text-xs ${darkMode ? 'text-gray-500' : 'text-gray-600'} text-right border-r ${darkMode ? 'border-gray-700' : 'border-gray-300'}`}>
+        <div className={`flex-none w-6 px-1 py-0.25 text-3xs ${darkMode ? 'text-gray-500' : 'text-gray-600'} text-right border-r ${darkMode ? 'border-gray-700' : 'border-gray-300'}`}>
           {line.newLineNumber || ''}
         </div>
-        <div className={`flex-none w-6 px-1 py-1 text-xs text-center font-mono ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+        <div className={`flex-none w-4 px-0.5 py-0.25 text-3xs text-center font-mono ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}>
           {getLineSymbol()}
         </div>
-        <div className={`flex-1 px-2 py-1 font-mono text-sm ${darkMode ? 'text-white' : 'text-gray-900'} whitespace-pre-wrap break-all overflow-hidden`}>
+        <div className={`flex-1 px-1 py-0.25 font-mono text-2xs leading-extra-tight ${darkMode ? 'text-white' : 'text-gray-900'} whitespace-pre-wrap break-all overflow-hidden`}>
           {line.content}
         </div>
-        <div className="flex-none opacity-0 group-hover:opacity-100 px-2 py-1">
+        <div className="flex-none opacity-0 group-hover:opacity-100 px-1 py-0.25">
           <button
             onClick={() => onAddNote(hunkId, line.newLineNumber || line.oldLineNumber)}
             className={`${darkMode ? 'text-gray-400 hover:text-blue-400' : 'text-gray-500 hover:text-blue-600'} transition-colors`}
             title={`Add note to line ${line.newLineNumber || line.oldLineNumber}`}
           >
-            <MessageSquare className="w-4 h-4" />
+            <MessageSquare className="w-3 h-3" />
           </button>
         </div>
       </div>
@@ -124,31 +124,31 @@ function DiffLineComponent({ line, hunkId, notes, onAddNote }: DiffLineProps) {
       {lineNotes.map((note) => (
         <div
           key={note.id}
-          className="border-l-2 border-gray-600 ml-6"
+          className="border-l-2 border-gray-600 ml-4"
         >
-          <div className={`mx-6 my-2 p-3 rounded-lg border ${
+          <div className={`mx-4 my-1 p-2 rounded border ${
             note.type === 'memo' 
               ? 'bg-blue-900/30 border-blue-700/50' 
               : 'bg-yellow-900/30 border-yellow-700/50'
           }`}>
             <div className="flex items-start">
-              <div className="flex-none mr-3 mt-1">
+              <div className="flex-none mr-2 mt-0.5">
                 {note.type === 'memo' ? (
-                  <StickyNote className="w-4 h-4 text-blue-400" />
+                  <StickyNote className="w-3 h-3 text-blue-400" />
                 ) : (
-                  <MessageSquare className="w-4 h-4 text-yellow-400" />
+                  <MessageSquare className="w-3 h-3 text-yellow-400" />
                 )}
               </div>
               <div className="flex-1">
                 <div className="flex items-center justify-between mb-1">
-                  <span className="text-xs text-gray-400">
+                  <span className="text-3xs text-gray-400">
                     {note.type === 'memo' ? 'Personal memo' : 'Review comment'}
                   </span>
-                  <span className="text-xs text-gray-500">
+                  <span className="text-3xs text-gray-500">
                     {new Date(note.createdAt).toLocaleTimeString()}
                   </span>
                 </div>
-                <p className="text-sm text-gray-200 whitespace-pre-wrap">
+                <p className="text-2xs text-gray-200 whitespace-pre-wrap">
                   {note.content}
                 </p>
               </div>
@@ -179,44 +179,44 @@ function HunkViewer({ hunk, notes, onStatusChange, onAddNote }: HunkViewerProps)
   const hunkNotes = notes.filter(note => !note.lineNumber)
 
   return (
-    <div className={`border ${darkMode ? 'border-gray-700' : 'border-gray-300'} rounded-lg mb-4 overflow-hidden`}>
+    <div className={`border ${darkMode ? 'border-gray-700' : 'border-gray-300'} rounded mb-2 overflow-hidden`}>
       {/* Hunk Header */}
-      <div className={`${darkMode ? 'bg-gray-800' : 'bg-gray-100'} px-4 py-3`}>
-        <div className="flex items-center space-x-3 mb-2">
+      <div className={`${darkMode ? 'bg-gray-800' : 'bg-gray-100'} px-2 py-1.5`}>
+        <div className="flex items-center space-x-2 mb-1">
           <button
             onClick={() => setIsExpanded(!isExpanded)}
             className={`${darkMode ? 'text-gray-400 hover:text-white' : 'text-gray-600 hover:text-gray-900'} transition-colors`}
             title={isExpanded ? "Collapse this hunk" : "Expand this hunk"}
           >
             {isExpanded ? (
-              <ChevronDown className="w-4 h-4" />
+              <ChevronDown className="w-3 h-3" />
             ) : (
-              <ChevronRight className="w-4 h-4" />
+              <ChevronRight className="w-3 h-3" />
             )}
           </button>
-          <code className={`text-sm ${darkMode ? 'text-gray-300' : 'text-gray-700'} font-mono`}>
+          <code className={`text-2xs ${darkMode ? 'text-gray-300' : 'text-gray-700'} font-mono`}>
             {hunk.header}
           </code>
-          <span className={`text-xs ${darkMode ? 'text-gray-500' : 'text-gray-600'}`}>
+          <span className={`text-3xs ${darkMode ? 'text-gray-500' : 'text-gray-600'}`}>
             {hunk.lines.length} lines
           </span>
 
           {/* Review Status and Actions */}
           <div className="flex-1 flex items-center justify-end space-x-2">
             {/* Review Status Indicator */}
-            <div className={`flex items-center px-2 py-1 rounded text-white text-xs ${
+            <div className={`flex items-center px-1 py-0.5 rounded text-white text-3xs ${
               hunk.reviewStatus === 'reviewed' ? 'bg-green-600' : 'bg-gray-600'
             }`}>
-              {hunk.reviewStatus === 'reviewed' && <Check className="w-4 h-4 mr-1" />}
+              {hunk.reviewStatus === 'reviewed' && <Check className="w-3 h-3 mr-0.5" />}
               <span className="capitalize">{hunk.reviewStatus}</span>
             </div>
 
             {/* Action Buttons */}
-            <div className="flex space-x-1">
+            <div className="flex space-x-0.5">
               {/* Review Toggle Button */}
               <button
                 onClick={toggleReviewStatus}
-                className={`px-2 py-1 rounded text-xs transition-colors ${
+                className={`px-1 py-0.5 rounded text-3xs transition-colors ${
                   hunk.reviewStatus === 'reviewed'
                     ? 'bg-green-600 text-white hover:bg-green-700'
                     : darkMode
@@ -230,7 +230,7 @@ function HunkViewer({ hunk, notes, onStatusChange, onAddNote }: HunkViewerProps)
               {/* Note Button */}
               <button
                 onClick={() => onAddNote(hunk.id)}
-                className={`px-2 py-1 rounded text-xs transition-colors ${
+                className={`px-1 py-0.5 rounded text-3xs transition-colors ${
                   darkMode
                     ? 'bg-gray-700 text-gray-300 hover:bg-blue-600 hover:text-white'
                     : 'bg-gray-300 text-gray-700 hover:bg-blue-600 hover:text-white'
@@ -245,18 +245,18 @@ function HunkViewer({ hunk, notes, onStatusChange, onAddNote }: HunkViewerProps)
 
         {/* Hunk Notes Display */}
         {hunkNotes.length > 0 && (
-          <div className="mt-2 space-y-2">
+          <div className="mt-1 space-y-1">
             {hunkNotes.map((note) => (
               <div
                 key={note.id}
-                className={`p-2 rounded border text-sm ${
+                className={`p-1 rounded border text-2xs ${
                   note.type === 'memo' 
                     ? 'bg-blue-900/20 border-blue-700/30 text-blue-200' 
                     : 'bg-yellow-900/20 border-yellow-700/30 text-yellow-200'
                 }`}
               >
                 <div className="flex items-start">
-                  <div className="flex-none mr-2 mt-0.5">
+                  <div className="flex-none mr-1 mt-0.25">
                     {note.type === 'memo' ? (
                       <StickyNote className="w-3 h-3" />
                     ) : (
@@ -265,7 +265,7 @@ function HunkViewer({ hunk, notes, onStatusChange, onAddNote }: HunkViewerProps)
                   </div>
                   <div className="flex-1">
                     <p className="whitespace-pre-wrap">{note.content}</p>
-                    <span className="text-xs opacity-75">
+                    <span className="text-3xs opacity-75">
                       {new Date(note.createdAt).toLocaleTimeString()}
                     </span>
                   </div>
@@ -301,29 +301,7 @@ export function DiffViewer({ hunks, notes, onStatusChange, onAddNote }: DiffView
   const totalCount = hunks.length
 
   return (
-    <div className="space-y-4">
-      {/* Progress Summary */}
-      <div className={`${darkMode ? 'bg-gray-800' : 'bg-gray-100'} rounded-lg p-4`}>
-        <div className="flex items-center justify-between mb-2">
-          <h3 className={`text-lg font-medium ${darkMode ? 'text-white' : 'text-gray-900'}`}>Review Progress</h3>
-          <div className="flex items-center space-x-4">
-            <span className={`text-sm ${darkMode ? 'text-gray-300' : 'text-gray-600'}`}>
-              {reviewedCount} / {totalCount} hunks reviewed
-            </span>
-            {/* View Mode Indicator */}
-            <span className={`text-xs px-2 py-1 rounded ${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-gray-200 text-gray-700'}`}>
-              {viewMode === 'split' ? 'Split View' : 'Unified View'}
-            </span>
-          </div>
-        </div>
-        <div className={`w-full ${darkMode ? 'bg-gray-700' : 'bg-gray-300'} rounded-full h-2`}>
-          <div
-            className="bg-green-600 h-2 rounded-full transition-all duration-300"
-            style={{ width: `${totalCount > 0 ? (reviewedCount / totalCount) * 100 : 0}%` }}
-          />
-        </div>
-      </div>
-
+    <div className="space-y-2">
       {/* Hunks */}
       {hunks.length === 0 ? (
         <div className={`text-center py-12 ${darkMode ? 'text-gray-500' : 'text-gray-600'}`}>

--- a/packages/frontend/src/components/DiffViewer.tsx
+++ b/packages/frontend/src/components/DiffViewer.tsx
@@ -295,10 +295,7 @@ function HunkViewer({ hunk, notes, onStatusChange, onAddNote }: HunkViewerProps)
 }
 
 export function DiffViewer({ hunks, notes, onStatusChange, onAddNote }: DiffViewerProps) {
-  const { viewMode, darkMode } = useSettingsStore()
-
-  const reviewedCount = hunks.filter(h => h.reviewStatus === 'reviewed').length
-  const totalCount = hunks.length
+  const { darkMode } = useSettingsStore()
 
   return (
     <div className="space-y-2">

--- a/packages/frontend/src/components/FileViewer.tsx
+++ b/packages/frontend/src/components/FileViewer.tsx
@@ -74,16 +74,30 @@ export function FileViewer({ file, notes, onStatusChange, onAddNote }: FileViewe
 
             <div className="flex flex-col">
               <div className="flex items-center space-x-2">
-                <span className={`font-mono text-sm ${getStatusColor(file.status, darkMode)}`}>
+                <span className={`font-mono text-2xs ${getStatusColor(file.status, darkMode)}`}>
                   {file.path}
                 </span>
-                <span className={`text-xs ${darkMode ? 'text-gray-500' : 'text-gray-600'} capitalize`}>
+                <span className={`text-3xs ${darkMode ? 'text-gray-500' : 'text-gray-600'} capitalize`}>
                   ({file.status})
                 </span>
+                {/* Review Progress inline */}
+                <div className="flex items-center space-x-1">
+                  <div className={`text-3xs ${darkMode ? 'text-gray-400' : 'text-gray-600'}`}>
+                    {reviewedHunks}/{totalHunks}
+                  </div>
+                  <div className={`w-12 ${darkMode ? 'bg-gray-700' : 'bg-gray-300'} rounded-full h-1`}>
+                    <div
+                      className="bg-green-600 h-1 rounded-full transition-all duration-300"
+                      style={{
+                        width: `${totalHunks > 0 ? (reviewedHunks / totalHunks) * 100 : 0}%`
+                      }}
+                    />
+                  </div>
+                </div>
               </div>
-              
+
               {file.oldPath && file.oldPath !== file.path && (
-                <span className={`text-xs ${darkMode ? 'text-gray-500' : 'text-gray-600'} font-mono`}>
+                <span className={`text-3xs ${darkMode ? 'text-gray-500' : 'text-gray-600'} font-mono`}>
                   {file.oldPath} → {file.path}
                 </span>
               )}
@@ -92,27 +106,12 @@ export function FileViewer({ file, notes, onStatusChange, onAddNote }: FileViewe
 
           <div className="flex items-center space-x-4 text-sm">
             {/* File Stats */}
-            <div className="flex items-center space-x-3 text-xs">
+            <div className="flex items-center space-x-3 text-3xs">
               <span className="text-green-500">+{addedLines}</span>
               <span className="text-red-500">-{deletedLines}</span>
               <span className={`${darkMode ? 'text-gray-400' : 'text-gray-600'}`}>
                 {totalHunks} {totalHunks === 1 ? 'hunk' : 'hunks'}
               </span>
-            </div>
-
-            {/* Review Progress */}
-            <div className="flex items-center space-x-2">
-              <div className={`text-xs ${darkMode ? 'text-gray-400' : 'text-gray-600'}`}>
-                {reviewedHunks}/{totalHunks} reviewed
-              </div>
-              <div className={`w-12 ${darkMode ? 'bg-gray-700' : 'bg-gray-300'} rounded-full h-1`}>
-                <div
-                  className="bg-green-600 h-1 rounded-full transition-all duration-300"
-                  style={{ 
-                    width: `${totalHunks > 0 ? (reviewedHunks / totalHunks) * 100 : 0}%` 
-                  }}
-                />
-              </div>
             </div>
           </div>
         </div>

--- a/packages/frontend/src/components/ReviewSession.tsx
+++ b/packages/frontend/src/components/ReviewSession.tsx
@@ -188,63 +188,63 @@ export function ReviewSession() {
       {/* Session Header */}
       <div className={`${darkMode ? 'bg-gray-800' : 'bg-gray-100'} rounded-lg p-6`}>
         <div className="flex items-center justify-between mb-4">
-          <h2 className={`text-xl font-semibold ${darkMode ? 'text-white' : 'text-gray-900'}`}>Code Review Session</h2>
-          <div className={`flex items-center space-x-4 text-sm ${darkMode ? 'text-gray-400' : 'text-gray-600'}`}>
+          <h2 className={`text-base font-semibold ${darkMode ? 'text-white' : 'text-gray-900'}`}>Code Review Session</h2>
+          <div className={`flex items-center space-x-4 text-2xs ${darkMode ? 'text-gray-400' : 'text-gray-600'}`}>
             <div className="flex items-center">
-              <Clock className="w-4 h-4 mr-1" aria-label="Last updated" />
+              <Clock className="w-3 h-3 mr-1" aria-label="Last updated" />
               {new Date(currentSession.updatedAt).toLocaleString()}
             </div>
           </div>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
-          <div className={`${darkMode ? 'bg-gray-700' : 'bg-gray-200'} rounded p-3`}>
-            <div className={`${darkMode ? 'text-gray-400' : 'text-gray-600'} text-xs uppercase`}>Repository</div>
-            <div className={`font-mono text-sm ${darkMode ? 'text-white' : 'text-gray-900'} truncate`}>
+          <div className={`${darkMode ? 'bg-gray-700' : 'bg-gray-200'} rounded p-2`}>
+            <div className={`${darkMode ? 'text-gray-400' : 'text-gray-600'} text-3xs uppercase`}>Repository</div>
+            <div className={`font-mono text-2xs ${darkMode ? 'text-white' : 'text-gray-900'} truncate`}>
               {currentSession.repositoryPath}
             </div>
           </div>
-          <div className={`${darkMode ? 'bg-gray-700' : 'bg-gray-200'} rounded p-3 group`}>
-            <div className={`${darkMode ? 'text-gray-400' : 'text-gray-600'} text-xs uppercase mb-2`}>Range</div>
+          <div className={`${darkMode ? 'bg-gray-700' : 'bg-gray-200'} rounded p-2 group`}>
+            <div className={`${darkMode ? 'text-gray-400' : 'text-gray-600'} text-3xs uppercase mb-1`}>Range</div>
             <RangeSelector
               currentRange={`${currentSession.baseCommit}..${currentSession.targetCommit}`}
               onRangeChange={updateRange}
               disabled={loading}
             />
           </div>
-          <div className={`${darkMode ? 'bg-gray-700' : 'bg-gray-200'} rounded p-3`}>
-            <div className={`${darkMode ? 'text-gray-400' : 'text-gray-600'} text-xs uppercase`}>Files Changed</div>
-            <div className={`text-sm ${darkMode ? 'text-white' : 'text-gray-900'}`}>
+          <div className={`${darkMode ? 'bg-gray-700' : 'bg-gray-200'} rounded p-2`}>
+            <div className={`${darkMode ? 'text-gray-400' : 'text-gray-600'} text-3xs uppercase`}>Files Changed</div>
+            <div className={`text-2xs ${darkMode ? 'text-white' : 'text-gray-900'}`}>
               {currentSession.files.length} files
             </div>
           </div>
         </div>
 
         {/* Progress Overview */}
-        <div className={`${darkMode ? 'bg-gray-700' : 'bg-gray-200'} rounded-lg p-4`}>
-          <div className="flex items-center justify-between mb-3">
-            <h3 className={`font-medium ${darkMode ? 'text-white' : 'text-gray-900'}`}>Review Progress</h3>
-            <div className={`text-sm ${darkMode ? 'text-gray-300' : 'text-gray-700'}`}>
-              {reviewedHunks} / {totalHunks} hunks reviewed
+        <div className={`${darkMode ? 'bg-gray-700' : 'bg-gray-200'} rounded-lg p-3`}>
+          <div className="flex items-center justify-between mb-2">
+            <h3 className={`text-2xs font-medium ${darkMode ? 'text-white' : 'text-gray-900'}`}>Review Progress</h3>
+            <div className={`text-3xs ${darkMode ? 'text-gray-300' : 'text-gray-700'}`}>
+              {reviewedHunks} / {totalHunks} hunks
             </div>
           </div>
-          
-          <div className="flex items-center space-x-4 mb-2">
-            <div className="flex items-center text-sm">
-              <CheckCircle className="w-4 h-4 text-green-500 mr-1" aria-label="Reviewed and approved hunks" />
-              <span className={`${darkMode ? 'text-gray-300' : 'text-gray-700'}`}>{reviewedHunks} reviewed</span>
+
+          <div className="flex items-center space-x-3 mb-1">
+            <div className="flex items-center text-3xs">
+              <CheckCircle className="w-3 h-3 text-green-500 mr-0.5" aria-label="Reviewed and approved hunks" />
+              <span className={`${darkMode ? 'text-gray-300' : 'text-gray-700'}`}>{reviewedHunks}</span>
             </div>
-            <div className="flex items-center text-sm">
-              <Clock className={`w-4 h-4 ${darkMode ? 'text-gray-500' : 'text-gray-600'} mr-1`} aria-label="Hunks awaiting review" />
-              <span className={`${darkMode ? 'text-gray-300' : 'text-gray-700'}`}>{unreviewedHunks} unreviewed</span>
+            <div className="flex items-center text-3xs">
+              <Clock className={`w-3 h-3 ${darkMode ? 'text-gray-500' : 'text-gray-600'} mr-0.5`} aria-label="Hunks awaiting review" />
+              <span className={`${darkMode ? 'text-gray-300' : 'text-gray-700'}`}>{unreviewedHunks}</span>
             </div>
           </div>
-          
-          <div className={`w-full ${darkMode ? 'bg-gray-600' : 'bg-gray-300'} rounded-full h-2`}>
+
+          <div className={`w-full ${darkMode ? 'bg-gray-600' : 'bg-gray-300'} rounded-full h-1`}>
             <div
-              className="bg-green-500 h-2 rounded-full transition-all duration-500"
-              style={{ 
-                width: `${totalHunks > 0 ? (reviewedHunks / totalHunks) * 100 : 0}%` 
+              className="bg-green-500 h-1 rounded-full transition-all duration-500"
+              style={{
+                width: `${totalHunks > 0 ? (reviewedHunks / totalHunks) * 100 : 0}%`
               }}
             />
           </div>

--- a/packages/frontend/src/components/Settings.tsx
+++ b/packages/frontend/src/components/Settings.tsx
@@ -38,47 +38,47 @@ export function Settings() {
   }
 
   return (
-    <div className={`${darkMode ? 'bg-gray-800' : 'bg-white'} rounded-lg p-6 max-w-2xl border ${darkMode ? 'border-gray-700' : 'border-gray-300'}`}>
-      <div className="flex items-center justify-between mb-6">
-        <h2 className={`text-lg font-medium ${darkMode ? 'text-white' : 'text-gray-900'}`}>Review Settings</h2>
-        <div className="flex space-x-2">
+    <div className={`${darkMode ? 'bg-gray-800' : 'bg-white'} rounded p-4 max-w-2xl border ${darkMode ? 'border-gray-700' : 'border-gray-300'}`}>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className={`text-base font-medium ${darkMode ? 'text-white' : 'text-gray-900'}`}>Review Settings</h2>
+        <div className="flex space-x-1">
           <button
             onClick={handleReset}
-            className={`flex items-center px-3 py-2 text-sm ${darkMode ? 'bg-gray-700 hover:bg-gray-600 text-gray-300' : 'bg-gray-200 hover:bg-gray-300 text-gray-700'} rounded-md transition-colors`}
+            className={`flex items-center px-2 py-1 text-2xs ${darkMode ? 'bg-gray-700 hover:bg-gray-600 text-gray-300' : 'bg-gray-200 hover:bg-gray-300 text-gray-700'} rounded transition-colors`}
           >
-            <RotateCcw className="w-4 h-4 mr-2" />
+            <RotateCcw className="w-3 h-3 mr-1" />
             Reset
           </button>
           <button
             onClick={handleSave}
             disabled={isSaving}
-            className={`flex items-center px-4 py-2 text-sm bg-blue-600 hover:bg-blue-700 ${darkMode ? 'disabled:bg-blue-800' : 'disabled:bg-blue-400'} text-white rounded-md transition-colors`}
+            className={`flex items-center px-2 py-1 text-2xs bg-blue-600 hover:bg-blue-700 ${darkMode ? 'disabled:bg-blue-800' : 'disabled:bg-blue-400'} text-white rounded transition-colors`}
           >
-            <Save className="w-4 h-4 mr-2" />
+            <Save className="w-3 h-3 mr-1" />
             {isSaving ? 'Saving...' : 'Save'}
           </button>
         </div>
       </div>
 
       {saveStatus === 'success' && (
-        <div className={`mb-4 p-3 ${darkMode ? 'bg-green-900/50 border-green-700 text-green-300' : 'bg-green-100 border-green-300 text-green-700'} border rounded-md`}>
-          <p className="text-sm">Settings saved successfully!</p>
+        <div className={`mb-2 p-2 ${darkMode ? 'bg-green-900/50 border-green-700 text-green-300' : 'bg-green-100 border-green-300 text-green-700'} border rounded`}>
+          <p className="text-2xs">Settings saved successfully!</p>
         </div>
       )}
 
       {saveStatus === 'error' && (
-        <div className={`mb-4 p-3 ${darkMode ? 'bg-red-900/50 border-red-700 text-red-300' : 'bg-red-100 border-red-300 text-red-700'} border rounded-md`}>
-          <p className="text-sm">Failed to save settings. Using local storage.</p>
+        <div className={`mb-2 p-2 ${darkMode ? 'bg-red-900/50 border-red-700 text-red-300' : 'bg-red-100 border-red-300 text-red-700'} border rounded`}>
+          <p className="text-2xs">Failed to save settings. Using local storage.</p>
         </div>
       )}
 
-      <div className="space-y-6">
+      <div className="space-y-4">
         {/* Context Lines */}
         <div>
-          <label className={`block text-sm font-medium ${darkMode ? 'text-gray-300' : 'text-gray-700'} mb-2`}>
+          <label className={`block text-2xs font-medium ${darkMode ? 'text-gray-300' : 'text-gray-700'} mb-1`}>
             Context Lines
           </label>
-          <div className="flex items-center space-x-4">
+          <div className="flex items-center space-x-2">
             <input
               type="range"
               min="0"
@@ -87,19 +87,19 @@ export function Settings() {
               onChange={(e) => updateSetting('contextLines', parseInt(e.target.value))}
               className={`flex-1 h-2 ${darkMode ? 'bg-gray-700' : 'bg-gray-300'} rounded-lg appearance-none cursor-pointer slider`}
             />
-            <span className={`${darkMode ? 'text-gray-300' : 'text-gray-700'} text-sm w-8`}>{contextLines}</span>
+            <span className={`${darkMode ? 'text-gray-300' : 'text-gray-700'} text-2xs w-8`}>{contextLines}</span>
           </div>
-          <p className={`text-xs ${darkMode ? 'text-gray-500' : 'text-gray-600'} mt-1`}>
+          <p className={`text-3xs ${darkMode ? 'text-gray-500' : 'text-gray-600'} mt-0.5`}>
             Number of context lines to show around changes
           </p>
         </div>
 
         {/* View Mode */}
         <div>
-          <label className={`block text-sm font-medium ${darkMode ? 'text-gray-300' : 'text-gray-700'} mb-2`}>
+          <label className={`block text-2xs font-medium ${darkMode ? 'text-gray-300' : 'text-gray-700'} mb-1`}>
             View Mode
           </label>
-          <div className="flex space-x-4">
+          <div className="flex space-x-2">
             <label className="flex items-center">
               <input
                 type="radio"
@@ -107,9 +107,9 @@ export function Settings() {
                 value="unified"
                 checked={viewMode === 'unified'}
                 onChange={(e) => updateSetting('viewMode', e.target.value as 'unified' | 'split')}
-                className={`h-4 w-4 text-blue-600 focus:ring-blue-500 ${darkMode ? 'border-gray-300 bg-gray-700' : 'border-gray-400 bg-white'}`}
+                className={`h-3 w-3 text-blue-600 focus:ring-blue-500 ${darkMode ? 'border-gray-300 bg-gray-700' : 'border-gray-400 bg-white'}`}
               />
-              <span className={`ml-2 text-sm ${darkMode ? 'text-gray-300' : 'text-gray-700'}`}>Unified</span>
+              <span className={`ml-1 text-2xs ${darkMode ? 'text-gray-300' : 'text-gray-700'}`}>Unified</span>
             </label>
             <label className="flex items-center">
               <input
@@ -118,19 +118,19 @@ export function Settings() {
                 value="split"
                 checked={viewMode === 'split'}
                 onChange={(e) => updateSetting('viewMode', e.target.value as 'unified' | 'split')}
-                className={`h-4 w-4 text-blue-600 focus:ring-blue-500 ${darkMode ? 'border-gray-300 bg-gray-700' : 'border-gray-400 bg-white'}`}
+                className={`h-3 w-3 text-blue-600 focus:ring-blue-500 ${darkMode ? 'border-gray-300 bg-gray-700' : 'border-gray-400 bg-white'}`}
               />
-              <span className={`ml-2 text-sm ${darkMode ? 'text-gray-300' : 'text-gray-700'}`}>Side by Side</span>
+              <span className={`ml-1 text-2xs ${darkMode ? 'text-gray-300' : 'text-gray-700'}`}>Side by Side</span>
             </label>
           </div>
         </div>
 
         {/* Toggle Options */}
-        <div className="space-y-4">
+        <div className="space-y-3">
           <div className="flex items-center justify-between">
             <label className="flex flex-col">
-              <span className={`text-sm font-medium ${darkMode ? 'text-gray-300' : 'text-gray-700'}`}>Dark Mode</span>
-              <span className={`text-xs ${darkMode ? 'text-gray-500' : 'text-gray-600'}`}>Use dark theme</span>
+              <span className={`text-2xs font-medium ${darkMode ? 'text-gray-300' : 'text-gray-700'}`}>Dark Mode</span>
+              <span className={`text-3xs ${darkMode ? 'text-gray-500' : 'text-gray-600'}`}>Use dark theme</span>
             </label>
             <label className="relative inline-flex items-center cursor-pointer">
               <input
@@ -139,14 +139,14 @@ export function Settings() {
                 onChange={(e) => updateSetting('darkMode', e.target.checked)}
                 className="sr-only peer"
               />
-              <div className={`w-11 h-6 ${darkMode ? 'bg-gray-600' : 'bg-gray-300'} peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-800 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600`}></div>
+              <div className={`w-8 h-4 ${darkMode ? 'bg-gray-600' : 'bg-gray-300'} peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-800 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[1px] after:left-[1px] after:bg-white after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:bg-blue-600`}></div>
             </label>
           </div>
 
           <div className="flex items-center justify-between">
             <label className="flex flex-col">
-              <span className={`text-sm font-medium ${darkMode ? 'text-gray-300' : 'text-gray-700'}`}>Show Whitespace</span>
-              <span className={`text-xs ${darkMode ? 'text-gray-500' : 'text-gray-600'}`}>Display whitespace characters</span>
+              <span className={`text-2xs font-medium ${darkMode ? 'text-gray-300' : 'text-gray-700'}`}>Show Whitespace</span>
+              <span className={`text-3xs ${darkMode ? 'text-gray-500' : 'text-gray-600'}`}>Display whitespace characters</span>
             </label>
             <label className="relative inline-flex items-center cursor-pointer">
               <input
@@ -155,14 +155,14 @@ export function Settings() {
                 onChange={(e) => updateSetting('showWhitespace', e.target.checked)}
                 className="sr-only peer"
               />
-              <div className={`w-11 h-6 ${darkMode ? 'bg-gray-600' : 'bg-gray-300'} peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-800 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600`}></div>
+              <div className={`w-8 h-4 ${darkMode ? 'bg-gray-600' : 'bg-gray-300'} peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-800 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[1px] after:left-[1px] after:bg-white after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:bg-blue-600`}></div>
             </label>
           </div>
         </div>
 
-        <div className={`pt-4 border-t ${darkMode ? 'border-gray-700' : 'border-gray-300'}`}>
-          <h3 className={`text-sm font-medium ${darkMode ? 'text-gray-300' : 'text-gray-700'} mb-2`}>Keyboard Shortcuts</h3>
-          <div className={`text-xs ${darkMode ? 'text-gray-500' : 'text-gray-600'} space-y-1`}>
+        <div className={`pt-2 border-t ${darkMode ? 'border-gray-700' : 'border-gray-300'}`}>
+          <h3 className={`text-2xs font-medium ${darkMode ? 'text-gray-300' : 'text-gray-700'} mb-1`}>Keyboard Shortcuts</h3>
+          <div className={`text-3xs ${darkMode ? 'text-gray-500' : 'text-gray-600'} space-y-0.5`}>
             <div><kbd className={`${darkMode ? 'bg-gray-700' : 'bg-gray-200'} px-1 rounded`}>j/k</kbd> - Next/Previous hunk</div>
             <div><kbd className={`${darkMode ? 'bg-gray-700' : 'bg-gray-200'} px-1 rounded`}>r</kbd> - Mark as reviewed</div>
             <div><kbd className={`${darkMode ? 'bg-gray-700' : 'bg-gray-200'} px-1 rounded`}>n</kbd> - Add note</div>

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -4,7 +4,7 @@
 
 :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
+  line-height: 1.4;
   font-weight: 400;
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
@@ -23,13 +23,32 @@ body {
 
 code {
   font-family: ui-monospace, SFMono-Regular, 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 10px;
+  line-height: 1.2;
+}
+
+/* Diff specific optimizations */
+.diff-line {
+  height: 16px;
+  min-height: 16px;
+}
+
+/* High density code display */
+.font-mono {
+  font-feature-settings: "liga" 0, "calt" 0;
+  letter-spacing: -0.025em;
+}
+
+/* Compact spacing for dense layouts */
+.compact {
+  line-height: 1.1;
 }
 
 /* Custom slider styles */
 .slider::-webkit-slider-thumb {
   appearance: none;
-  height: 20px;
-  width: 20px;
+  height: 16px;
+  width: 16px;
   border-radius: 50%;
   background: #3b82f6;
   cursor: pointer;
@@ -37,8 +56,8 @@ code {
 }
 
 .slider::-moz-range-thumb {
-  height: 20px;
-  width: 20px;
+  height: 16px;
+  width: 16px;
   border-radius: 50%;
   background: #3b82f6;
   cursor: pointer;
@@ -52,4 +71,16 @@ code {
 
 .bg-gray-850 {
   background-color: #1f2937;
+}
+
+/* Optimized hover states for dense UI */
+.hover\:bg-gray-750:hover {
+  background-color: #374151;
+}
+
+/* Better focus states for small elements */
+.focus\:ring-1:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
 }

--- a/packages/frontend/tailwind.config.js
+++ b/packages/frontend/tailwind.config.js
@@ -10,7 +10,21 @@ export default {
         'diff-add': '#22c55e',
         'diff-delete': '#ef4444',
         'diff-context': '#64748b',
-      }
+      },
+      fontSize: {
+        '2xs': ['10px', '14px'],
+        '3xs': ['9px', '12px'],
+        '4xs': ['8px', '11px'],
+        '5xs': ['7px', '10px'],
+      },
+      spacing: {
+        '0.25': '1px',
+        '0.75': '3px',
+      },
+      lineHeight: {
+        'extra-tight': '1.1',
+        'super-tight': '1.0',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- Embed review progress (x/y hunks) inline with file names in FileViewer
- Add compact progress bars next to file names  
- Remove duplicate Review Progress sections from DiffViewer
- Reduce font sizes throughout the UI for more compact display

## Changes Made
- **FileViewer**: Added inline review progress display next to file names with compact progress bars
- **DiffViewer**: Removed redundant Progress Summary section to avoid duplication
- **Font sizes**: Reduced throughout UI (file names: text-sm → text-2xs, status info: text-xs → text-3xs)
- **Tailwind config**: Added new smaller font sizes (text-4xs, text-5xs) for future use
- **Layout**: Reduced padding and spacing for denser, more efficient display

## Visual Changes
- File names now show progress inline: `filename.js (modified) 1/3 [progress bar]`
- More compact overall layout with smaller fonts
- Eliminated duplicate progress sections

## Test Plan
- [x] Build passes (`pnpm build`)
- [x] Type checking passes (`pnpm type-check`) 
- [x] Linting passes (`pnpm lint`)
- [x] All tests pass (`pnpm test`)
- [x] UI tested with Playwright for visual correctness

🤖 Generated with [Claude Code](https://claude.ai/code)