### PR TITLE
Add codecov integration for CI code coverage reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        slug: garaemon/reviewflow
         fail_ci_if_error: true
         files: packages/frontend/coverage/lcov.info,packages/backend/coverage/lcov.info
         flags: unittests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
       run: pnpm test:coverage
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,5 +44,14 @@ jobs:
     - name: Build
       run: pnpm build
     
-    - name: Test
-      run: pnpm test
+    - name: Test with coverage
+      run: pnpm test:coverage
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
+        files: packages/frontend/coverage/lcov.info,packages/backend/coverage/lcov.info
+        flags: unittests
+        name: codecov-umbrella

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,36 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+        threshold: 1%
+
+codecov:
+  require_ci_to_pass: yes
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+
+ignore:
+  - "tests/**/*"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/dist/**"
+  - "**/build/**"
+  - "**/node_modules/**"
+  - "*.config.*"
+  - "playwright.config.ts"
+
+flag_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: 80%
+      - type: patch
+        target: 80%

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "pnpm -r build",
     "dev": "pnpm -r --parallel dev",
     "test": "pnpm -r test",
+    "test:coverage": "pnpm -r test:coverage",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "lint": "pnpm -r lint",


### PR DESCRIPTION
## Summary
- Add codecov configuration for code coverage reporting in CI
- Configure CI workflow to upload coverage reports to codecov
- Set coverage targets at 80% for both project and patch coverage

## Changes
- **codecov.yml**: Configuration file with coverage targets and ignore patterns
- **.github/workflows/test.yml**: Updated to run tests with coverage and upload reports
- **package.json**: Added test:coverage script for monorepo coverage execution

## Test plan
- [x] Tests pass locally with coverage reporting
- [x] Type checking passes
- [x] Linting passes
- [x] CI workflow runs successfully and uploads coverage to codecov (requires CODECOV_TOKEN secret)

🤖 Generated with [Claude Code](https://claude.ai/code)